### PR TITLE
bump version number to make debugging easier (cant tell what coursera builds have update)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-run-diff",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-run-diff",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"devDependencies": {
 				"@types/glob": "^7.1.3",
 				"@types/mocha": "^8.0.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"publisher": "joyceerhl",
 	"preview": true,
 	"description": "Run and diff Python output",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"engines": {
 		"vscode": "^1.60.0"
 	},


### PR DESCRIPTION
From respecting the executing directory